### PR TITLE
feat: 有害事象に対する信頼区間提示部分の修正

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -796,7 +796,7 @@ AE_each_item = function(dat, group_var, group_labels,
   
   if(with_95CI){
     tmp = c(paste0(whole, ' (', round2(whole/N*100, 1), ')'), 
-            paste0(round2(whole_CI$lower*100, 1), ", ", round2(whole_CI$upper*100, 1)))
+            paste0(round2(whole_CI$conf.int[1]*100, 1), ", ", round2(whole_CI$conf.int[2]*100, 1)))
   }else{
     tmp = c(paste0(whole, ' (', round2(whole/N*100, 1), ')'))
   }
@@ -821,7 +821,7 @@ AE_each_item = function(dat, group_var, group_labels,
     
     if(with_95CI){
       tmp %<>% c(paste0(whole, ' (', round2(whole/N*100, 1), ')'), 
-                 paste0(round2(whole_CI$lower*100, 1), ", ", round2(whole_CI$upper*100, 1)))
+                 paste0(round2(whole_CI$conf.int[1]*100, 1), ", ", round2(whole_CI$conf.int[2]*100, 1)))
     }else{
       tmp %<>% c(paste0(whole, ' (', round2(whole/N*100, 1), ')'))
     }
@@ -878,7 +878,7 @@ AE_each_item_by_cate = function(dat, group_var, group_labels,
       
       if(with_95CI){
         tmp %<>% c(paste0(N_each_cate, ' (', round2(N_each_cate/N*100, 1), ')'), 
-                   paste0(round2(CI$lower*100, 1), ", ", round2(CI$upper*100, 1)))
+                   paste0(round2(CI$conf.int[1]*100, 1), ", ", round2(CI$conf.int[2]*100, 1)))
       }else{
         tmp %<>% c(paste0(N_each_cate, ' (', round2(N_each_cate/N*100, 1), ')'))
       }
@@ -909,7 +909,7 @@ AE_each_item_by_cate = function(dat, group_var, group_labels,
         
         if(with_95CI){
           tmp %<>% c(paste0(N_each_cate, ' (', round2(N_each_cate/N*100, 1), ')'), 
-                     paste0(round2(CI$lower*100, 1), ", ", round2(CI$upper*100, 1)))
+                     paste0(round2(CI$conf.int[1]*100, 1), ", ", round2(CI$conf.int[2]*100, 1)))
         }else{
           tmp %<>% c(paste0(N_each_cate, ' (', round2(N_each_cate/N*100, 1), ')'))
         }      }


### PR DESCRIPTION
有害事象の発現割合に対する信頼区間を提示できないバグを修正．

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes 95% CI display for adverse event proportions by using binom.exact$conf.int indices instead of $lower/$upper.
> 
> - **AE summary (proportions)**:
>   - Update CI extraction to use `binom.exact$conf.int[1:2]` (was `$lower`/`$upper`).
>   - Affects `functions.R`:
>     - `AE_each_item(...)`: overall and per-group CI outputs.
>     - `AE_each_item_by_cate(...)`: overall and per-group CI outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3ed1cf25c0f486e1aa720ea110b1e52475a681c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->